### PR TITLE
fix reading matrix buckets

### DIFF
--- a/src/eq_classes.cpp
+++ b/src/eq_classes.cpp
@@ -92,7 +92,7 @@ void write_eq_class_matrix(string& output, vector<ofstream*>& all_files, uint64_
 		vector<count_vector> count_vecs;
 		robin_hood::unordered_map<string, pair<count_vector, vector<uint64_t>>> bucket_class;
 		string compressed;
-		zstr::ifstream in(output + "/matrix_bucket_"+ to_string(i) + ".gz"); //TODO zstr??
+		ifstream in(output + "/matrix_bucket_"+ to_string(i) + ".gz"); //TODO zstr??
 		if (not is_empty_zfile(in)){
 			in.peek();
 			while (not in.eof() and not in.fail())


### PR DESCRIPTION
These files are written with `std::ofstream` in https://github.com/kamimrcht/REINDEER/blob/3b527c975bc398ecca5c62d309e68fd3f9b93b1d/src/build_index.cpp#L76
Thus, they should probably be read with `std::ifstream` and not `zstr::ifstream`.